### PR TITLE
Limit push sizes and spread jobs over multiple pushes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,3 @@
+# HEAD
+
+* Have `push_bulk` limit the size of each push, with a default of 10,000 jobs each. Add `push_bulk!` which does not limit. (#1)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,39 @@ all_users.each do |user|
 end
 ```
 
+## Job count splitting
+
+`push_bulk` will only enqueue at most 10,000 jobs at a time. That is, if `items` has 20,000 elements, `push_bulk(items)` will push the first 10,000, then the second 20,000. You can control the threshold with `limit:`.
+
+```ruby
+# push in groups of 50,000 jobs at a time
+FooJob.push_bulk(items, limit: 50_000)
+
+# equivalent to FooJob.push_bulk(items, limit: 10_000)
+FooJob.push_bulk(items)
+```
+
+This also works with a block.
+
+```ruby
+# this results in 5 pushes
+
+users.length # => 100_000
+FooJob.push_bulk(users, limit: 20_000) do |user|
+  [user.id, "some-value"]
+end
+```
+
+And to disable push splitting, use `push_bulk!`.
+
+```ruby
+# one single push of 500,000 jobs, no splitting
+
+FooJob.push_bulk!(users) do |user|
+  [user.id, "some-value"]
+end
+```
+
 ### License
 
 Copyright (c) 2015 Adam Prescott, licensed under the MIT license. See LICENSE.

--- a/lib/sidekiq/bulk.rb
+++ b/lib/sidekiq/bulk.rb
@@ -1,5 +1,13 @@
+require "active_support/core_ext/array/grouping"
+
 module SidekiqBulk
-  def push_bulk(items, &block)
+  def push_bulk(items, limit: 10_000, &block)
+    items.in_groups_of(limit, false).each do |group|
+      push_bulk!(group, &block)
+    end
+  end
+
+  def push_bulk!(items, &block)
     if block
       args = items.map(&block)
     else

--- a/sidekiq-bulk.gemspec
+++ b/sidekiq-bulk.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT"]
 
   s.add_dependency("sidekiq")
+  s.add_dependency("activesupport")
   s.add_development_dependency("rspec", ">= 3.3")
   s.add_development_dependency("rspec-sidekiq")
   s.add_development_dependency("pry-byebug")

--- a/spec/sidekiq_bulk_spec.rb
+++ b/spec/sidekiq_bulk_spec.rb
@@ -10,41 +10,122 @@ RSpec.describe SidekiqBulk do
   class BarJob < FooJob
   end
 
-  it "provides a push_bulk method on job classes" do
-    expect(FooJob).to respond_to(:push_bulk)
+  shared_examples "a bulk push method" do |method_name|
+    it "provides a push_bulk method on job classes" do
+      expect(FooJob).to respond_to(method_name)
+    end
+
+    it "enqueues the job" do
+      FooJob.public_send(method_name, [1, 2, 3]) { |el| [2*el, "some-value"] }
+
+      expect(FooJob.jobs.length).to eq(3)
+      expect(FooJob).to have_enqueued_job(2, "some-value")
+      expect(FooJob).to have_enqueued_job(4, "some-value")
+      expect(FooJob).to have_enqueued_job(6, "some-value")
+    end
+
+    it "goes through the Sidekiq::Client interface" do
+      expect(Sidekiq::Client).to receive(:push_bulk).once.with("class" => FooJob, "args" => [[1], [2], [3]])
+
+      FooJob.public_send(method_name, [1, 2, 3])
+    end
+
+    it "uses the correct class name for subclasses" do
+      expect(Sidekiq::Client).to receive(:push_bulk).once.with("class" => BarJob, "args" => [[1], [2], [3]])
+
+      BarJob.push_bulk([1, 2, 3])
+    end
+
+    it "defaults to the identity function with no block given" do
+      FooJob.public_send(method_name, [10, -6.1, "a thing"])
+
+      expect(FooJob.jobs.length).to eq(3)
+      expect(FooJob).to have_enqueued_job(10)
+      expect(FooJob).to have_enqueued_job(-6.1)
+      expect(FooJob).to have_enqueued_job("a thing")
+    end
   end
 
-  it "enqueues the job" do
-    FooJob.push_bulk([1, 2, 3]) { |el| [el, "some-value"] }
+  describe "#push_bulk" do
+    include_examples "a bulk push method", :push_bulk
 
-    expect(FooJob.jobs.length).to eq(3)
-    expect(FooJob).to have_enqueued_job(1, "some-value")
-    expect(FooJob).to have_enqueued_job(2, "some-value")
-    expect(FooJob).to have_enqueued_job(3, "some-value")
+    it "limits the size of groups" do
+      FooJob.push_bulk([1, 2, 3, 4, 5, 6, 7], limit: 3)
+
+      expect(FooJob.jobs.length).to eq(7)
+      expect(FooJob).to have_enqueued_job(1)
+      expect(FooJob).to have_enqueued_job(2)
+      expect(FooJob).to have_enqueued_job(3)
+      expect(FooJob).to have_enqueued_job(4)
+      expect(FooJob).to have_enqueued_job(5)
+      expect(FooJob).to have_enqueued_job(6)
+      expect(FooJob).to have_enqueued_job(7)
+    end
+
+    it "limits with the item transformation" do
+      allow(Sidekiq::Client).to receive(:push_bulk)
+
+      FooJob.push_bulk([1, 2, 3, 4, 5, 6, 7], limit: 4) do |item|
+        [2*item, "some-value"]
+      end
+
+      expect(Sidekiq::Client).to have_received(:push_bulk).exactly(2).times
+      expect(Sidekiq::Client).to have_received(:push_bulk).with("class" => FooJob, "args" => [[2, "some-value"], [4, "some-value"], [6, "some-value"], [8, "some-value"]])
+      expect(Sidekiq::Client).to have_received(:push_bulk).with("class" => FooJob, "args" => [[10, "some-value"], [12, "some-value"], [14, "some-value"]])
+    end
+
+    it "goes through the Sidekiq::Client interface" do
+      allow(Sidekiq::Client).to receive(:push_bulk)
+
+      FooJob.push_bulk([1, 2, 3, 4, 5, 6, 7], limit: 3)
+
+      expect(Sidekiq::Client).to have_received(:push_bulk).exactly(3).times
+      expect(Sidekiq::Client).to have_received(:push_bulk).with("class" => FooJob, "args" => [[1], [2], [3]])
+      expect(Sidekiq::Client).to have_received(:push_bulk).with("class" => FooJob, "args" => [[4], [5], [6]])
+      expect(Sidekiq::Client).to have_received(:push_bulk).with("class" => FooJob, "args" => [[7]])
+    end
+
+    context "when no limit is specified" do
+      let(:item_count) { 9_999 }
+
+      before do
+        allow(Sidekiq::Client).to receive(:push_bulk)
+
+        FooJob.push_bulk((1..item_count).to_a)
+      end
+
+      context "when the item count is 10,000" do
+        let(:item_count) { 10_000 }
+
+        specify { expect(Sidekiq::Client).to have_received(:push_bulk).exactly(1).times }
+      end
+
+      context "when the item count is 10,001" do
+        let(:item_count) { 10_001 }
+
+        specify { expect(Sidekiq::Client).to have_received(:push_bulk).exactly(2).times }
+      end
+
+      context "when the item count is 40,000" do
+        let(:item_count) { 40_000 }
+
+        specify { expect(Sidekiq::Client).to have_received(:push_bulk).exactly(4).times }
+      end
+    end
   end
 
-  it "goes through the Sidekiq::Client interface" do
-    expect(Sidekiq::Client).to receive(:push_bulk).with("class" => FooJob, "args" => [[1], [2], [3]])
+  describe "#push_bulk!" do
+    include_examples "a bulk push method", :push_bulk!
 
-    FooJob.push_bulk([1, 2, 3])
-  end
+    it "does not limit the number of jobs in one push" do
+      expect(Sidekiq::Client).to receive(:push_bulk).once.with("class" => FooJob, "args" => (1..100_000).map { |e| [e] })
 
-  it "uses the correct class name for subclasses" do
-    expect(Sidekiq::Client).to receive(:push_bulk).with("class" => BarJob, "args" => [[1], [2], [3]])
-
-    BarJob.push_bulk([1, 2, 3])
-  end
-
-  it "defaults to the identity function with no block given" do
-    FooJob.push_bulk([1, 2, 3])
-
-    expect(FooJob.jobs.length).to eq(3)
-    expect(FooJob).to have_enqueued_job(1)
-    expect(FooJob).to have_enqueued_job(2)
-    expect(FooJob).to have_enqueued_job(3)
+      FooJob.push_bulk!((1..100_000).to_a)
+    end
   end
 
   describe "inline test", sidekiq: :inline do
     specify { expect { FooJob.push_bulk([1, 2, 3]) }.to raise_error(RuntimeError, "1") }
+    specify { expect { FooJob.push_bulk!([1, 2, 3]) }.to raise_error(RuntimeError, "1") }
   end
 end


### PR DESCRIPTION
*(Note: the initial version had the roles of `push_bulk` and `push_bulk!` reversed, where `push_bulk!` did splitting, and `push_bulk` did not.)*

`push_bulk` will now split pushes into groups. Those groups will, by default, be at most 10,000 jobs in size.

For example, `push_bulk([1, 2, 3, 4, 5], limit: 3)` will limit each push to at most 3 items. That makes

```ruby
push_bulk([1, 2, 3, 4, 5], limit: 3) { ... }
```

equivalent to pushing `[1, 2, 3]`, then `[4, 5]` separately. The default `limit:` value is `10_000`.

`push_bulk!` is also added as a way to push in bulk without any spreading — all jobs are pushed in one go.