### PR TITLE
Remove a require ordering dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # HEAD
 
-* ...
+* Remove a `require` ordering dependency. (#2)
 
 # v0.1
 

--- a/lib/sidekiq/bulk.rb
+++ b/lib/sidekiq/bulk.rb
@@ -1,3 +1,4 @@
+require "sidekiq"
 require "active_support/core_ext/array/grouping"
 
 module SidekiqBulk

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require "sidekiq"
 require "sidekiq/bulk"
 require "sidekiq/testing"
 require "rspec"


### PR DESCRIPTION
Without this, you have to `require "sidekiq"` first. That's a problem with something like Bundler.require.