### PR TITLE
Return the enqueued job ids from push_back

### DIFF
--- a/lib/sidekiq/bulk.rb
+++ b/lib/sidekiq/bulk.rb
@@ -2,9 +2,11 @@ require "sidekiq"
 
 module SidekiqBulk
   def push_bulk(items, limit: 10_000, &block)
-    items.each_slice(limit).each do |group|
+    job_ids = items.each_slice(limit).map do |group|
       push_bulk!(group, &block)
     end
+
+    job_ids.flatten
   end
 
   def push_bulk!(items, &block)

--- a/spec/sidekiq_bulk_spec.rb
+++ b/spec/sidekiq_bulk_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe SidekiqBulk do
       expect(FooJob).to have_enqueued_sidekiq_job(-6.1)
       expect(FooJob).to have_enqueued_sidekiq_job("a thing")
     end
+
+    it "returns the enqueued job ids" do
+      allow(Sidekiq::Client).to receive(:push_bulk).and_return(["jid-1", "jid-2", "jid-3"])
+
+      job_ids = FooJob.public_send(method_name, [1, 2, 3])
+
+      expect(job_ids).to match_array(["jid-1", "jid-2", "jid-3"])
+    end
   end
 
   describe "#push_bulk" do


### PR DESCRIPTION
Fixes `push_back` so that it returns the expected array of enqueued Sidekiq job ids instead of the job arguments themselves.